### PR TITLE
Fix ListObjectVersions to return only maxkeys

### DIFF
--- a/cmd/metacache-entries.go
+++ b/cmd/metacache-entries.go
@@ -281,12 +281,17 @@ func (m *metaCacheEntriesSorted) iterate(fn func(entry metaCacheEntry) (cont boo
 
 // fileInfoVersions converts the metadata to FileInfoVersions where possible.
 // Metadata that cannot be decoded is skipped.
-func (m *metaCacheEntriesSorted) fileInfoVersions(bucket, prefix, delimiter string) (versions []ObjectInfo, commonPrefixes []string) {
+func (m *metaCacheEntriesSorted) fileInfoVersions(bucket, prefix, delimiter, afterV string) (versions []ObjectInfo, commonPrefixes []string) {
 	versions = make([]ObjectInfo, 0, m.len())
 	prevPrefix := ""
 	for _, entry := range m.o {
 		if entry.isObject() {
 			fiv, err := entry.fileInfoVersions(bucket)
+			if afterV != "" {
+				// Forward first entry to specified version
+				fiv.forwardPastVersion(afterV)
+				afterV = ""
+			}
 			if err == nil {
 				for _, version := range fiv.Versions {
 					versions = append(versions, version.ToObjectInfo(bucket, entry.name))

--- a/cmd/storage-datatypes.go
+++ b/cmd/storage-datatypes.go
@@ -59,6 +59,19 @@ type FileInfoVersions struct {
 	Versions []FileInfo
 }
 
+// forwardPastVersion will truncate the result to only contain versions after 'v'.
+// If v is empty or the version isn't found no changes will be made.
+func (f *FileInfoVersions) forwardPastVersion(v string) {
+	if v == "" {
+		return
+	}
+	for i, ver := range f.Versions {
+		if ver.VersionID == v {
+			f.Versions = f.Versions[i+1:]
+		}
+	}
+}
+
 // FileInfo - represents file stat information.
 type FileInfo struct {
 	// Name of the volume.

--- a/cmd/storage-datatypes.go
+++ b/cmd/storage-datatypes.go
@@ -68,6 +68,7 @@ func (f *FileInfoVersions) forwardPastVersion(v string) {
 	for i, ver := range f.Versions {
 		if ver.VersionID == v {
 			f.Versions = f.Versions[i+1:]
+			return
 		}
 	}
 }


### PR DESCRIPTION
## Description

The existing implementation will return maxkeys *objects* and all version of those, whereas S3 returns no more than maykeys *versions*.

This will only return the specified number of versions and set the NextVersionIDMarker appropriately.

## How to test this PR?

Upload many versions of the same object. Ensure that it is listing ok.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
